### PR TITLE
Update version file URLs to current repo owner

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/ExpPack.version
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/ExpPack.version
@@ -1,9 +1,9 @@
 {
      "NAME":"USI Exploration Pack",
-	 "URL":"https://raw.githubusercontent.com/BobPalmer/ExplorationPack/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/ExpPack.version",
-	 "DOWNLOAD":"https://github.com/BobPalmer/ExplorationPack/releases",
+	 "URL":"https://raw.githubusercontent.com/UmbraSpaceIndustries/ExplorationPack/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/ExpPack.version",
+	 "DOWNLOAD":"https://github.com/UmbraSpaceIndustries/ExplorationPack/releases",
      "GITHUB":{
-         "USERNAME":"BobPalmer",
+         "USERNAME":"UmbraSpaceIndustries",
          "REPOSITORY":"ExplorationPack",
          "ALLOW_PRE_RELEASE":false
      },


### PR DESCRIPTION
Hi @BobPalmer,

The URLs in this mod's version file are slightly out of date, they still have the previous repo owner. GitHub helpfully silently redirects them, so they still work, but this can sometimes trrigger GitHub's server-side rate limiting behavior.

Now they're updated to the latest correct values.