### PR TITLE
Updated biomeMask values in ScienceDefs

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/SciencePack/Patches/ScienceDefs.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/SciencePack/Patches/ScienceDefs.cfg
@@ -35,14 +35,14 @@ EXPERIMENT_DEFINITION
 
 EXPERIMENT_DEFINITION
 {
-    id = USI_CosmicDustAnalyzer    
+    id = USI_CosmicDustAnalyzer
     title = Cosmic Dust Analyzer
     baseValue = 16
     scienceCap = 16
     dataScale = 2
     requireAtmosphere = False
     situationMask = 48
-    biomeMask = 48
+    biomeMask = 0// No biomes: Only valid in space low or high
     RESULTS
     {
         default = Cosmic dust is the primordial ooze of existance, creating life, the Universe, everything.
@@ -66,7 +66,7 @@ EXPERIMENT_DEFINITION
     dataScale = 2
     requireAtmosphere = False
     situationMask = 48
-    biomeMask = 51
+    biomeMask = 0// No biomes: Only valid in space low or high
     RESULTS
     {
         default = Infrared Spectroscopy provides insight into the composition of the object beneath you.
@@ -82,7 +82,7 @@ EXPERIMENT_DEFINITION
     dataScale = 2
     requireAtmosphere = False
     situationMask = 48
-    biomeMask = 51
+    biomeMask = 16// Biomes only for in space low
     RESULTS
     {
         default = You begin scanning the surface below searching for interesting features
@@ -113,7 +113,7 @@ EXPERIMENT_DEFINITION
     dataScale = 2
     requireAtmosphere = False
     situationMask = 15
-    biomeMask = 15
+    biomeMask = 3// Biomes on surface only (same as stock barometer)
     RESULTS
     {
         default = As the sensors deploy, they begin logging data on the complicated interplay between the atmosphere, the surface beneath, and the sun above.
@@ -157,8 +157,8 @@ EXPERIMENT_DEFINITION
     scienceCap = 18
     dataScale = 2
     requireAtmosphere = False
-    situationMask = 3
-    biomeMask = 3
+    situationMask = 1
+    biomeMask = 1// Biomes only when landed (not on water)
     RESULTS
     {
         default = Using a combination of high energy radiation and methylethelbadstuff is certainly an effective way to find out what something is made of. You take several several steps away from the machine, just to be safe.
@@ -173,8 +173,8 @@ EXPERIMENT_DEFINITION
     scienceCap = 18
     dataScale = 2
     requireAtmosphere = False
-    situationMask = 3
-    biomeMask = 3
+    situationMask = 1
+    biomeMask = 1// Biomes only when landed (not on water)
     RESULTS
     {
         default = The radar returns an image of the geology below the vessel
@@ -201,7 +201,7 @@ EXPERIMENT_DEFINITION
     dataScale = 2
     requireAtmosphere = False
     situationMask = 48
-    biomeMask = 48
+    biomeMask = 0// No biomes: Only valid in space low or high
     RESULTS
     {
         default = Observation of high energy particles will provide data on both Kerbol and this planet as waves of energy crash into it
@@ -221,7 +221,7 @@ EXPERIMENT_DEFINITION
     dataScale = 2
     requireAtmosphere = False
     situationMask = 48
-    biomeMask = 48
+    biomeMask = 0// No biomes: Only valid in space low or high
     RESULTS
     {
         default = You begin to transmit radio waves of various frequencies, observing how they are absorbed, reflected, and refracted by the atmosphere and magnetosphere at certain times of the day
@@ -237,7 +237,7 @@ EXPERIMENT_DEFINITION
     dataScale = 2
     requireAtmosphere = False
     situationMask = 48
-    biomeMask = 48
+    biomeMask = 0// No biomes: Only valid in space low or high
     RESULTS
     {
         default = Aiming the dish at the target you begin recording data for analysis.
@@ -250,7 +250,7 @@ EXPERIMENT_DEFINITION
         JoolInSpace= ....- ..--- Certainly these signals must hold the answers to life, the universe, something???
         DunaInSpace = .--. --- - .- - --- ... You've spent too much time on this project, you even see patterns on the planetary surface
         LaytheInSpace =  - --- .-- . .-.. You have a niggling feeling you forgot something.
-    
+
 }
 
 EXPERIMENT_DEFINITION
@@ -261,8 +261,8 @@ EXPERIMENT_DEFINITION
     scienceCap = 18
     dataScale = 2
     requireAtmosphere = False
-    situationMask = 15
-    biomeMask = 15
+    situationMask = 5
+    biomeMask = 5// Biomes only landed and flying low
     RESULTS
     {
         default = As the laser begins to vaporize bits of material for the spectrometer to analyze, you begin to wonder if this technology could be used to heat snacks...


### PR DESCRIPTION
Updates to biomeMask (and some situationMask) values.

Some had mismatches between situationMask and biomeMask where biomes were factored into situations the experiment could not run.

Some did not make sense for the experiment (e.g. Ground radar & litho experiment not on water, or space based experiments having biomes for both in space high and low)

Generally biomeMask for 0 for most space-only experiments for balance, and reflecting Squad's balancing of the magnetometer. (Biome specific in-space experiments vastly increase how much science one experiment can produce)